### PR TITLE
BSD needs atomic stubs too

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -4686,7 +4686,7 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-#ifdef LINUX
+#if defined(LINUX) || defined(_ALLBSD_SOURCE)
 
   // ARMv8.1 LSE versions of the atomic stubs used by Atomic::PlatformXX.
   //
@@ -4849,7 +4849,7 @@ class StubGenerator: public StubCodeGenerator {
 
     ICache::invalidate_range(first_entry, __ pc() - first_entry);
   }
-#endif // LINUX
+#endif // LINUX || _ALLBSD_SOURCE
 
   void generate_base64_encode_simdround(Register src, Register dst,
         FloatRegister codec, u8 size) {
@@ -6082,11 +6082,11 @@ class StubGenerator: public StubCodeGenerator {
     generate_safefetch("SafeFetchN", sizeof(intptr_t), &StubRoutines::_safefetchN_entry,
                                                        &StubRoutines::_safefetchN_fault_pc,
                                                        &StubRoutines::_safefetchN_continuation_pc);
-#ifdef LINUX
+#if defined(LINUX) || defined(_ALLBSD_SOURCE)
 
     generate_atomic_entry_points();
 
-#endif // LINUX
+#endif // LINUX || _ALLBSD_SOURCE
 
   StubRoutines::aarch64::set_completed();
   }
@@ -6106,7 +6106,7 @@ void StubGenerator_generate(CodeBuffer* code, bool all) {
 }
 
 
-#ifdef LINUX
+#if defined(LINUX) || defined(_ALLBSD_SOURCE)
 
 // Define pointers to atomic stubs and initialize them to point to the
 // code in atomic_aarch64.S.
@@ -6130,4 +6130,4 @@ DEFAULT_ATOMIC_OP(cmpxchg, 8, _relaxed)
 
 #undef DEFAULT_ATOMIC_OP
 
-#endif // LINUX
+#endif // LINUX || _ALLBSD_SOURCE


### PR DESCRIPTION
This fixes the build on *BSD for aarch64.