### PR TITLE
Fix build with Clang13 and OpenBSD/aarch64

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -210,14 +210,6 @@ else ifeq ($(OPENJDK_TARGET_OS), bsd)
   endif
 
   ifeq ($(TOOLCHAIN_TYPE), clang)
-    ifeq ($(OPENJDK_TARGET_CPU), x86)
-      ifneq ($(DEBUG_LEVEL), slowdebug)
-        # hotspot/jtreg/compiler/c2/Test8062950.java test fails on x86
-        # with clang when parse2.cpp is optimized above -O1
-        BUILD_LIBJVM_parse2.cpp_CXXFLAGS := -O1
-      endif
-    endif
-
     # The following files are compiled at various optimization
     # levels due to optimization issues encountered at the
     # default level. The Clang compiler issues a compile
@@ -233,14 +225,47 @@ else ifeq ($(OPENJDK_TARGET_OS), bsd)
         sharedRuntimeTrans.cpp \
         loopTransform.cpp \
         unsafe.cpp \
-        parse2.cpp \
         #
 
-    ifeq ($(OPENJDK_TARGET_CPU), aarch64)
+    ifneq ($(DEBUG_LEVEL), slowdebug)
+      # needed for clang 13
+      BUILD_LIBJVM_synchronizer.cpp_CXXFLAGS := -O1
+
       JVM_PRECOMPILED_HEADER_EXCLUDE += \
-          memnode.cpp
+          synchronizer.cpp \
           #
-      BUILD_LIBJVM_memnode.cpp_CXXFLAGS := -O0
+
+      ifeq ($(OPENJDK_TARGET_CPU), x86)
+        # hotspot/jtreg/compiler/c2/Test8062950.java test fails on x86
+        # with clang when parse2.cpp is optimized above -O1
+        BUILD_LIBJVM_parse2.cpp_CXXFLAGS := -O1
+
+        # needed for clang 13
+        BUILD_LIBJVM_vmreg_x86.cpp_CXXFLAGS := -O1
+
+        JVM_PRECOMPILED_HEADER_EXCLUDE += \
+            parse2.cpp \
+            vmreg_x86.cpp \
+            #
+      endif
+      ifeq ($(OPENJDK_TARGET_CPU), x86_64)
+        # needed for clang 13
+        BUILD_LIBJVM_vmreg_x86.cpp_CXXFLAGS := -O1
+
+        JVM_PRECOMPILED_HEADER_EXCLUDE += \
+            vmreg_x86.cpp \
+            #
+      endif
+      ifeq ($(OPENJDK_TARGET_CPU), aarch64)
+        BUILD_LIBJVM_memnode.cpp_CXXFLAGS := -O0
+        # needed for clang 13
+        BUILD_LIBJVM_immediate_$(HOTSPOT_TARGET_CPU).cpp_CXXFLAGS := -O1
+
+        JVM_PRECOMPILED_HEADER_EXCLUDE += \
+            memnode.cpp \
+            immediate_$(HOTSPOT_TARGET_CPU).cpp \
+          #
+      endif
     endif
   endif
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1492,7 +1492,7 @@ void MacroAssembler::movptr(Register r, uintptr_t imm64) {
 #ifndef PRODUCT
   {
     char buffer[64];
-    snprintf(buffer, sizeof(buffer), PTR64_FORMAT, imm64);
+    snprintf(buffer, sizeof(buffer), "0x%"PRIX64, (uint64_t)imm64);
     block_comment(buffer);
   }
 #endif
@@ -5811,7 +5811,7 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
 // Save whatever non-callee save context might get clobbered by
 // Thread::current.
 void MacroAssembler::get_thread(Register dst) {
-  RegSet saved_regs = RegSet::range(r0, r18) + lr - dst;
+  RegSet saved_regs = RegSet::range(r0, r18_tls) + lr - dst;
   push(saved_regs, sp);
 
   MacroAssembler::call_VM_leaf_base(CAST_FROM_FN_PTR(address, Thread::current), 0);

--- a/src/hotspot/cpu/aarch64/register_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.hpp
@@ -57,10 +57,16 @@ class RegisterImpl: public AbstractRegisterImpl {
   VMReg as_VMReg();
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                         { assert(is_valid(), "invalid register"); return (intptr_t)this; }
   bool  is_valid() const                         { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   bool  has_byte_register() const                { return 0 <= (intptr_t)this && (intptr_t)this < number_of_byte_registers; }
   const char* name() const;
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding_nocheck() const                 { return (intptr_t)this; }
 
   // Return the bit which represents this register.  This is intended
@@ -154,7 +160,13 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
   FloatRegister successor() const                          { return as_FloatRegister((encoding() + 1) % 32); }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                          { assert(is_valid(), "invalid register"); return (intptr_t)this; }
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding_nocheck() const                         { return (intptr_t)this; }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;

--- a/src/hotspot/cpu/x86/register_x86.hpp
+++ b/src/hotspot/cpu/x86/register_x86.hpp
@@ -63,6 +63,9 @@ class RegisterImpl: public AbstractRegisterImpl {
   inline VMReg as_VMReg();
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                         { assert(is_valid(), "invalid register"); return (intptr_t)this; }
   bool  is_valid() const                         { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   bool  has_byte_register() const                { return 0 <= (intptr_t)this && (intptr_t)this < number_of_byte_registers; }
@@ -118,6 +121,9 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
   FloatRegister successor() const                          { return as_FloatRegister(encoding() + 1); }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                          { assert(is_valid(), "invalid register"); return (intptr_t)this; }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;
@@ -164,6 +170,9 @@ class XMMRegisterImpl: public AbstractRegisterImpl {
   XMMRegister successor() const                          { return as_XMMRegister(encoding() + 1); }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                          { assert(is_valid(), "invalid register (%d)", (int)(intptr_t)this ); return (intptr_t)this; }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;
@@ -248,6 +257,9 @@ public:
   KRegister successor() const                          { return as_KRegister(encoding() + 1); }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                          { assert(is_valid(), "invalid register (%d)", (int)(intptr_t)this); return (intptr_t)this; }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;

--- a/src/hotspot/cpu/zero/register_zero.hpp
+++ b/src/hotspot/cpu/zero/register_zero.hpp
@@ -57,6 +57,9 @@ class RegisterImpl : public AbstractRegisterImpl {
   }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int encoding() const {
     assert(is_valid(), "invalid register");
     return (intptr_t)this;
@@ -92,6 +95,9 @@ class FloatRegisterImpl : public AbstractRegisterImpl {
   }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int encoding() const {
     assert(is_valid(), "invalid register");
     return (intptr_t)this;

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -206,6 +206,9 @@ class LIR_OprDesc: public CompilationResourceObj {
   friend class LIR_OprFact;
 
   // Conversion
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   intptr_t value() const                         { return (intptr_t) this; }
 
   bool check_value_mask(intptr_t mask, intptr_t masked_value) const {

--- a/src/hotspot/share/code/vmreg.hpp
+++ b/src/hotspot/share/code/vmreg.hpp
@@ -109,6 +109,9 @@ public:
   }
 
 
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   intptr_t value() const         {return (intptr_t) this; }
 
   void print_on(outputStream* st) const;

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -37,6 +37,9 @@ class Metadata : public MetaspaceObj {
   NOT_PRODUCT(Metadata()     { _valid = 0; })
   NOT_PRODUCT(bool is_valid() const volatile { return _valid == 0; })
 
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int identity_hash()                { return (int)(uintptr_t)this; }
 
   // Rehashing support for tables containing pointers to this


### PR DESCRIPTION
* Use printf format that is portable. uintptr_t is not compatible with PTR64_FORMAT on OpenBSD.
* r18 was renamed to r18_tls. Update OpenBSD's get_thread to use new name.
* Work around using 'this' as a tagged pointer by preventing inlining with clang 13.
* The jdk uses tagged pointers on 'this' which clang knows to be aligned and then optimizes away the tags. Reduce optimization levels to address this and avoid segfaults with clang 13.