### PR TITLE
Remove errant aarch64 hotspot assembly instruction that was reading

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1321,7 +1321,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     __ ldr(r10, Address(rmethod, Method::native_function_offset()));
     address unsatisfied = (SharedRuntime::native_method_throw_unsatisfied_link_error_entry());
     __ mov(rscratch2, unsatisfied);
-    __ ldr(rscratch2, rscratch2);
     __ cmp(r10, rscratch2);
     __ br(Assembler::NE, L);
     __ call_VM(noreg,


### PR DESCRIPTION
from libjvm.so .text segment.

Greg, I would appreciate another set of eyes on this commit. While I'm confident it is correct, it is a bug that affects aarch64 1.8 - current on all operating systems. OpenBSD implemented non-readable, execute only text segments (e.g. can execute but not readable independently without executing it). This revealed this bit of code on aarch64 that was reading libjvm.so .text segment.  When comparing the assembly of aarch64 to x86 it was clear this reading of the .text segment was not intended. Here's the x86 relevant code:

https://github.com/openjdk/jdk11u/blob/master/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp#L996

The intent is to compare the native method address to the address for SharedRuntime::native_method_throw_unsatisfied_link_error_entry() and if they are equal then call InterpreterRuntime::prepare_native_call. However, on aarch64 without my patch it takes the address
of SharedRuntime::native_method_throw_unsatisfied_link_error_entry(), dereferences it and loads the binary code at the entry point into rscratch2 and then compares that to native method address. The dereference is the bug that I have removed.

 