### PR TITLE
Eliminate custom OpenBSD aarch64 MacroAssembler::get_thread()

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -101,12 +101,6 @@ else ifeq ($(call And, $(call isTargetOs, linux) $(call isTargetCpu, aarch64)), 
   endif
 endif
 
-ifeq ($(call And, $(call isTargetOs, bsd) $(call isTargetCpu, aarch64)), true)
-  ifeq ($(OPENJDK_TARGET_OS_ENV), bsd.openbsd)
-    JVM_EXCLUDE_FILES += threadLS_bsd_aarch64.s
-  endif
-endif
-
 ifeq ($(call isTargetOs, linux macosx bsd windows), true)
   JVM_PRECOMPILED_HEADER := $(TOPDIR)/src/hotspot/share/precompiled/precompiled.hpp
 endif

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5843,22 +5843,6 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
   csel(result, result, zr, EQ);
 }
 
-#ifdef __OpenBSD__
-// OpenBSD uses emulated tls so it can't use aarch64_get_thread_helper().
-// Save whatever non-callee save context might get clobbered by
-// Thread::current.
-void MacroAssembler::get_thread(Register dst) {
-  RegSet saved_regs = RegSet::range(r0, r18_tls) + lr - dst;
-  push(saved_regs, sp);
-
-  MacroAssembler::call_VM_leaf_base(CAST_FROM_FN_PTR(address, Thread::current), 0);
-  if (dst != c_rarg0) {
-    mov(dst, c_rarg0);
-  }
-
-  pop(saved_regs, sp);
-}
-#else
 // get_thread() can be called anywhere inside generated code so we
 // need to save whatever non-callee save context might get clobbered
 // by the call to JavaThread::aarch64_get_thread_helper() or, indeed,
@@ -5882,4 +5866,3 @@ void MacroAssembler::get_thread(Register dst) {
 
   pop(saved_regs, sp);
 }
-#endif

--- a/src/hotspot/os_cpu/bsd_aarch64/threadLS_bsd_aarch64.s
+++ b/src/hotspot/os_cpu/bsd_aarch64/threadLS_bsd_aarch64.s
@@ -19,7 +19,7 @@
 // or visit www.oracle.com if you need additional information or have any
 // questions.
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__OpenBSD__)
         // JavaThread::aarch64_get_thread_helper()
         //
         // Return the current thread pointer in x0.
@@ -43,4 +43,4 @@ _ZN10JavaThread25aarch64_get_thread_helperEv:
 	ret
 
 	.size _ZN10JavaThread25aarch64_get_thread_helperEv, .-_ZN10JavaThread25aarch64_get_thread_helperEv
-#endif // !__APPLE__
+#endif // !__APPLE__ && !__OpenBSD__

--- a/src/hotspot/os_cpu/bsd_aarch64/thread_bsd_aarch64.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/thread_bsd_aarch64.hpp
@@ -61,7 +61,7 @@ private:
   bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
 public:
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
   static Thread *aarch64_get_thread_helper() {
     return Thread::current();
   }


### PR DESCRIPTION
implementation and replace with simpler approach used by Apple.