### PR TITLE
Use the correct number of cpus when hw.smt=0 on OpenBSD

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -327,7 +327,11 @@ void os::Bsd::initialize_system_info() {
 
   // get processors count via hw.ncpus sysctl
   mib[0] = CTL_HW;
+#if defined(HW_NCPUONLINE)
+  mib[1] = HW_NCPUONLINE;
+#else
   mib[1] = HW_NCPU;
+#endif
   len = sizeof(cpu_val);
   if (sysctl(mib, 2, &cpu_val, &len, NULL, 0) != -1 && cpu_val >= 1) {
     assert(len == sizeof(cpu_val), "unexpected data size");


### PR DESCRIPTION
Original diff submitted by Kirill A. Korinsky <kirill@korins.ky>