### PR TITLE
Fix building zero variant with clang on BSD

### DIFF
--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -30,11 +30,12 @@
 #define SUPPORTS_NATIVE_CX8
 #endif
 
+#include <ffi.h>
+
 #ifndef FFI_GO_CLOSURES
 #define FFI_GO_CLOSURES 0
 #endif
 
-#include <ffi.h>
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/java.desktop/share/native/libharfbuzz/hb-meta.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-meta.hh
@@ -199,7 +199,7 @@ template <> struct hb_int_max<signed long long>         : hb_integral_constant<s
 template <> struct hb_int_max<unsigned long long>       : hb_integral_constant<unsigned long long,      ULLONG_MAX>     {};
 #define hb_int_max(T) hb_int_max<T>::value
 
-#if defined(__GNUC__) && __GNUC__ < 5
+#if defined(__GNUC__) && __GNUC__ < 5 && !defined(__clang__)
 #define hb_is_trivially_copyable(T) __has_trivial_copy(T)
 #define hb_is_trivially_copy_assignable(T) __has_trivial_assign(T)
 #define hb_is_trivially_constructible(T) __has_trivial_constructor(T)


### PR DESCRIPTION
This work was sponsored by The FreeBSD Foundation.