### PR TITLE
Various minor corrections

### DIFF
--- a/.github/actions/do-build-vm/action.yml
+++ b/.github/actions/do-build-vm/action.yml
@@ -75,7 +75,7 @@ runs:
       shell: bash
 
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failure-logs-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: failure-logs
@@ -83,7 +83,7 @@ runs:
 
       # This is the best way I found to abort the job with an error message
     - name: 'Notify about build failures'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: core.setFailed('Build failed. See summary for details.')
       if: steps.check.outputs.failure == 'true'

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: 'Restore Cached VM Packages'
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -178,7 +178,7 @@ jobs:
           sudo df -h
 
       - name: 'Save VM Packages'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,7 +281,7 @@ jobs:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
       vm-arch: 'x86_64'
-      vm-release: "7.8"
+      vm-release: '7.9'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.openbsd-x64 == 'true'
@@ -341,7 +341,7 @@ jobs:
     with:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
-      vm-release: 7.8
+      vm-release: 7.9
       vm-arch: x86_64
 
   test-freebsd-x64:

--- a/.github/workflows/test-freebsd.yml
+++ b/.github/workflows/test-freebsd.yml
@@ -201,7 +201,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -209,7 +209,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/.github/workflows/test-openbsd.yml
+++ b/.github/workflows/test-openbsd.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Restore Cached VM Packages
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -218,7 +218,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -226,7 +226,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
+++ b/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
@@ -398,7 +398,7 @@ Java_sun_java2d_xr_XRBackendNative_createPixmap(JNIEnv *env, jobject this,
 JNIEXPORT jint JNICALL
 Java_sun_java2d_xr_XRBackendNative_createPictureNative
  (JNIEnv *env, jclass cls, jint drawable, jlong formatPtr) {
-  XRenderPictureAttributes pict_attr;
+  XRenderPictureAttributes pict_attr = { 0 };
   return XRenderCreatePicture(awt_display, (Drawable) drawable,
                               (XRenderPictFormat *) jlong_to_ptr(formatPtr),
                                0, &pict_attr);

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -38,6 +38,12 @@
   #define FORK() fork1()
 #endif
 
+#define RESTARTABLE(_cmd, _result) do { \
+  do { \
+    _result = _cmd; \
+  } while((_result == -1) && (errno == EINTR)); \
+} while(0)
+
 static char *skipWhitespace(char *p) {
     while ((*p != '\0') && isspace(*p)) {
         p++;
@@ -102,6 +108,14 @@ dbgsysExec(char *cmdLine)
 
     if ((pid = FORK()) == 0) {
         /* Child process */
+#if defined(_BSDONLY_SOURCE)
+#if defined(__FreeBSD__)
+     closefrom(STDERR_FILENO + 1);
+#else
+    int err;
+    RESTARTABLE(closefrom(STDERR_FILENO + 1), err);
+#endif
+#else // _BSDONLY_SOURCE
         int i;
         long max_fd;
 
@@ -111,6 +125,7 @@ dbgsysExec(char *cmdLine)
         for (i = 3; i < (int)max_fd; i++) {
             (void)close(i);
         }
+#endif
 
         (void)execvp(argv[0], argv);
 


### PR DESCRIPTION
Except for the GHA changes, these are from patches in OpenBSD packages - moving them up stream here:
GHA: Use OpenBSD 7.9 for building and testing
GHA: Upgrade Node.js 20 to 24
Use restartable closefrom(2) for BSD, except FreeBSD which uses
closefrom(2) that does not need restarts.
Fix building with clang 22:
error: variable 'pict_attr' is uninitialized when passed as a const pointer argument here [-Werror,-Wuninitialized-const-pointer]