### PR TITLE
GHA: Upgrade Node.js 20 to 24 - part 2

### DIFF
--- a/.github/workflows/build-freebsd.yml
+++ b/.github/workflows/build-freebsd.yml
@@ -88,7 +88,7 @@ jobs:
           sudo df -h
 
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set the BootJDK path'
         id: bootjdk

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -88,7 +88,7 @@ jobs:
           sudo df -h
 
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set the BootJDK path'
         id: bootjdk

--- a/.github/workflows/test-freebsd.yml
+++ b/.github/workflows/test-freebsd.yml
@@ -112,7 +112,7 @@ jobs:
           sudo df -h
 
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set the BootJDK path'
         id: bootjdk

--- a/.github/workflows/test-openbsd.yml
+++ b/.github/workflows/test-openbsd.yml
@@ -117,7 +117,7 @@ jobs:
           sudo df -h
 
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set the BootJDK path'
         id: bootjdk


### PR DESCRIPTION
I missed one case of the Node 20 to 24 upgrade. Warnings are sill generated because upstream hasn’t updated to remove them under the actions subdirectory.  