### PR TITLE
BSD Serviceability

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
@@ -50,6 +50,8 @@ public class DynLibsTest {
             osDependentBaseString = "lib%s.so";
         } else if (Platform.isLinux()) {
             osDependentBaseString = "lib%s.so";
+        } else if (Platform.isBSD()) {
+            osDependentBaseString = "lib%s.so";
         } else if (Platform.isOSX()) {
             osDependentBaseString = "lib%s.dylib";
         } else if (Platform.isSolaris()) {

--- a/test/hotspot/jtreg/testlibrary_tests/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/hotspot/jtreg/testlibrary_tests/TestMutuallyExclusivePlatformPredicates.java
@@ -52,7 +52,7 @@ public class TestMutuallyExclusivePlatformPredicates {
         MODE("isInt", "isMixed", "isComp"),
         IGNORED("isEmulatedClient", "isDebugBuild", "isFastDebugBuild", "isSlowDebugBuild",
                 "hasSA", "isRoot", "isTieredSupported", "areCustomLoadersSupportedForCDS",
-                "isHardenedOSX", "hasOSXPlistEntries", "isOracleLinux7");
+                "isHardenedOSX", "hasOSXPlistEntries", "isOracleLinux7", "isOpenBSD");
 
         public final List<String> methodNames;
 

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -144,6 +144,10 @@ public class Platform {
         return osName.toLowerCase().endsWith("bsd");
     }
 
+    public static boolean isOpenBSD() {
+        return osName.toLowerCase().equals("openbsd");
+    }
+
     private static boolean isOs(String osname) {
         return osName.toLowerCase().startsWith(osname.toLowerCase());
     }
@@ -250,6 +254,8 @@ public class Platform {
             return false; // SA is not enabled.
         }
         if (isAix()) {
+            return false; // SA not implemented.
+        } else if (isOpenBSD()) {
             return false; // SA not implemented.
         } else if (isLinux()) {
             if (isS390x() || isARM()) {


### PR DESCRIPTION
One difference in jdk11u compared to jdk17u:
It does not have the TestMutuallyExclusivePlatformPredicates.java‎ test